### PR TITLE
Fixed closing } for extern C

### DIFF
--- a/applications/benchmarks/dma_benchmarking/mpfs-dma-benchmarking/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/benchmarks/dma_benchmarking/mpfs-dma-benchmarking/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -616,4 +616,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-aes-cryptography/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-aes-cryptography/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-ccm-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-ccm-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-dsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-dsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-ecdsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-ecdsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-key-agreement-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-key-agreement-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-key-tree-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-key-tree-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-message-authentication-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-message-authentication-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-ndrbg-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-ndrbg-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-rsa-cryptography-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-rsa-cryptography-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/applications/user-crypto/mpfs-user-crypto-rsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/applications/user-crypto/mpfs-user-crypto-rsa-services/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/fpga-ip/CoreAXI4DMAController/mpfs-coreaxi4dma-block-transfer/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/fpga-ip/CoreAXI4DMAController/mpfs-coreaxi4dma-block-transfer/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/fpga-ip/CoreAXI4DMAController/mpfs-coreaxi4dma-stream/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/fpga-ip/CoreAXI4DMAController/mpfs-coreaxi4dma-stream/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/fpga-ip/CorePWM/mpfs-corepwm-slow-blink/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/fpga-ip/CorePWM/mpfs-corepwm-slow-blink/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-gpio/mpfs-gpio-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-gpio/mpfs-gpio-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-i2c/mpfs-i2c-mcp7941x-rtc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-i2c/mpfs-i2c-mcp7941x-rtc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-i2c/mpfs-i2c-pac1934-sensor/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-i2c/mpfs-i2c-pac1934-sensor/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-mmc/mpfs-emmc-command-queue/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-mmc/mpfs-emmc-command-queue/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -577,4 +577,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-mmc/mpfs-emmc-sd-write-read/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-mmc/mpfs-emmc-sd-write-read/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -577,4 +577,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-mmuart/mpfs-mmuart-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-mmuart/mpfs-mmuart-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-pdma/mpfs-pdma-read-write/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-pdma/mpfs-pdma-read-write/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -616,4 +616,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-qspi/mpfs-qspi-mt25q-flash/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-qspi/mpfs-qspi-mt25q-flash/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-qspi/mpfs-qspi-w25n01gv-flash/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-qspi/mpfs-qspi-w25n01gv-flash/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-rtc/mpfs-rtc-time/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-rtc/mpfs-rtc-time/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-usb/mpfs-usb-device-hid/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-usb/mpfs-usb-device-hid/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-usb/mpfs-usb-device-msc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-usb/mpfs-usb-device-msc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-usb/mpfs-usb-device-uvc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-usb/mpfs-usb-device-uvc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-usb/mpfs-usb-host-hid/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-usb/mpfs-usb-host-hid/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-usb/mpfs-usb-host-msc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-usb/mpfs-usb-host-msc/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -601,4 +601,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */

--- a/driver-examples/mss/mss-watchdog/mpfs-watchdog-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
+++ b/driver-examples/mss/mss-watchdog/mpfs-watchdog-interrupt/src/platform/drivers/mss/mss_pdma/mss_pdma.h
@@ -578,4 +578,8 @@ MSS_PDMA_clear_transfer_error_status
     mss_pdma_channel_id_t channel_id
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* MSS_PDMA_H */


### PR DESCRIPTION
# Description

In the file mss_pdma.h, which is located in ~30 places, it uses the 
```
#ifdef __cplusplus
extern "C" {
#endif 
```
for C++ cross compilation. But it is missing the necessary closing bracket
```
#ifdef __cplusplus
}
#endif
```
preventing compilation and throwing an error. 

I simply added the closing bracket that is present in all other `.c` and `.h` files as far as I have found. This is a minor fix for C++ compilation. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the mss pdma sample code, I inserted it into a C++ project in SoftConsole (using the Hello World C++ as a base). I then made the change and compiled it. Such a changed allowed the example code to compile unlike before and work just like the C version. 

**Test Configuration**:
* Reference design release:
* Hardware: 
* HSS version:
* Bare metal examples version:
* Buildroot / Yocto release:

# Checklist:

- [X] I have reviewed my code
- [ ] I have made corresponding changes to the documentation 
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
