### PR TITLE
added preprocessor directive to prevent writes on PCDMA_S2MM_LEN when

### DIFF
--- a/applications/mpfs-blank-baremetal/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/applications/mpfs-blank-baremetal/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/fpga-ip/CorePWM/mpfs-corepwm-slow-blink/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/fpga-ip/CorePWM/mpfs-corepwm-slow-blink/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mpfs-hal/mpfs-hal-ddr-demo/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mpfs-hal/mpfs-hal-ddr-demo/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-i2c/mpfs-i2c-master-slave/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-i2c/mpfs-i2c-master-slave/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-mmc/mpfs-emmc-sd-write-read/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-mmc/mpfs-emmc-sd-write-read/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-pdma/mpfs-pdma-read-write/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-pdma/mpfs-pdma-read-write/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-spi/mpfs-spi-master-slave/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-spi/mpfs-spi-master-slave/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-timer/mpfs-timer-example/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-timer/mpfs-timer-example/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.

--- a/driver-examples/mss/mss-watchdog/mpfs-watchdog-interrupt/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
+++ b/driver-examples/mss/mss-watchdog/mpfs-watchdog-interrupt/src/platform/drivers/fpga_ip/CoreAXI4ProtoConv/core_axi4protoconv.c
@@ -90,11 +90,13 @@ void PCDMA_S2MM_configure
     if((xfr_size != 0u) && (cmd_id <= S2MM_CMD_STS_FIFO_DEPTH_MAX) && \
                                       (burst_type <= PCDMA_BURST_TYPE_INCR) )
     {
+#ifdef IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE
         /* Configure transfer size for the total number of bytes to be
          * transmitted.
          */
         HAL_set_32bit_reg( this_pcdma->base_address, \
                                    COREAXI4PROTOCONV_REGS_S2MM_LEN, xfr_size );
+#endif
 
         /* Configure the lower 32-bits address of the AXI4 memory mapped
          * interface.


### PR DESCRIPTION
configuring PCDMA_S2MM_LEN

# Description

The `PCDMA_S2MM_configure()` function would always write on the `COREAXI4PROTOCONV_REGS_S2MM_LEN`. I disabled the configuration of the S2MM length register if the `IP_Config_S2MM_UNDEFINED_BURST_LENGTH_ENABLE` preprocessor directive enabled.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on a modified PolarFire SoC reference design incorporating the CoreAXI4ProtoConv IP. Validated that register writes to the LEN register no longer occur when the undefined burst length directive is active, matching expected fabric behavior.

**Test Configuration**:
* Reference design release:
* Hardware: Polarfire SoC Discovery Kit
* HSS version: I am using LIM Debug release
* Bare metal examples version: I am using my modified bare metal application
* Buildroot / Yocto release: NA

# Checklist:

- [x] I have reviewed my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
